### PR TITLE
test: add test for commit/push method

### DIFF
--- a/pkg/ghpr/ghpr_test.go
+++ b/pkg/ghpr/ghpr_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-billy/v5/util"
 
-	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage"
@@ -74,22 +74,6 @@ func initGitRepo() (*git.Repository, error) {
 	wt.Commit("first commit!", &git.CommitOptions{Author: &object.Signature{Name: "test", Email: "test.test"}})
 
 	return repository, nil
-}
-
-func setupMockGoGit(t *testing.T) *mockGoGit {
-	gitRepo, err := initGitRepo()
-	assert.Nil(t, err)
-
-	mockGit := new(mockGoGit)
-	mockGit.On("Clone",
-		mock.MatchedBy(func(s storage.Storer) bool { return true }),
-		mock.MatchedBy(func(c *chroot.ChrootHelper) bool { return true }),
-		mock.MatchedBy(func(c *git.CloneOptions) bool {
-			return c.URL == "https://github.com/shteou/go-ghpr"
-		}),
-	).Return(gitRepo, nil)
-
-	return mockGit
 }
 
 func TestMakeGithubPR(t *testing.T) {

--- a/pkg/ghpr/ghpr_test.go
+++ b/pkg/ghpr/ghpr_test.go
@@ -21,14 +21,13 @@ import (
 )
 
 // mockGoGit is a partial mock of go-git
-// It mocks out the externally interfacing methods (e.g. clone/push)
-// but forwards the others to go-git where it can operate on the repository
+// It mocks out the externally interfacing methods (e.g. clone), but
+// forwards the others to go-git where it can operate on the repository
 // in memory
 type mockGoGit struct {
 	mock.Mock
 }
 
-// Use testify
 func (g *mockGoGit) Clone(s storage.Storer, worktree billy.Filesystem, o *git.CloneOptions) (*git.Repository, error) {
 	args := g.Called(s, worktree, o)
 

--- a/pkg/ghpr/ghpr_test.go
+++ b/pkg/ghpr/ghpr_test.go
@@ -2,22 +2,33 @@ package ghpr
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/helper/chroot"
 	"github.com/go-git/go-billy/v5/memfs"
-	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v5/util"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-// Testify!!
+// mockGoGit is a partial mock of go-git
+// It mocks out the externally interfacing methods (e.g. clone/push)
+// but forwards the others to go-git where it can operate on the repository
+// in memory
 type mockGoGit struct {
 	mock.Mock
 }
 
+// Use testify
 func (g *mockGoGit) Clone(s storage.Storer, worktree billy.Filesystem, o *git.CloneOptions) (*git.Repository, error) {
 	args := g.Called(s, worktree, o)
 
@@ -26,6 +37,59 @@ func (g *mockGoGit) Clone(s storage.Storer, worktree billy.Filesystem, o *git.Cl
 	}
 
 	return args.Get(0).(*git.Repository), args.Error(1)
+}
+
+func (g *mockGoGit) Push(o *git.PushOptions) error {
+
+	return nil
+}
+
+// Initialises a basic git repository, makes a minimal initial commit
+// and sets the origin remote. This emulates a typical cloned repository
+func initGitRepo() (*git.Repository, error) {
+	fs := memfs.New()
+	storer := memory.NewStorage()
+
+	repository, err := git.Init(storer, fs)
+	if err != nil {
+		return nil, err
+	}
+
+	wt, err := repository.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	wtFs := wt.Filesystem
+
+	_, err = wtFs.Create("test")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = wt.Add("test")
+	if err != nil {
+		return nil, err
+	}
+
+	wt.Commit("first commit!", &git.CommitOptions{Author: &object.Signature{Name: "test", Email: "test.test"}})
+
+	return repository, nil
+}
+
+func setupMockGoGit(t *testing.T) *mockGoGit {
+	gitRepo, err := initGitRepo()
+	assert.Nil(t, err)
+
+	mockGit := new(mockGoGit)
+	mockGit.On("Clone",
+		mock.MatchedBy(func(s storage.Storer) bool { return true }),
+		mock.MatchedBy(func(c *chroot.ChrootHelper) bool { return true }),
+		mock.MatchedBy(func(c *git.CloneOptions) bool {
+			return c.URL == "https://github.com/shteou/go-ghpr"
+		}),
+	).Return(gitRepo, nil)
+
+	return mockGit
 }
 
 func TestMakeGithubPR(t *testing.T) {
@@ -126,4 +190,68 @@ func TestCloneFailure(t *testing.T) {
 
 	// Then there are no errors
 	assert.NotNil(t, err)
+}
+
+func commitNothing(w *git.Worktree) (string, *object.Signature, error) {
+	f, _ := w.Filesystem.Create("test_file")
+	_, _ = f.Write([]byte("My data"))
+	_ = f.Close()
+	w.Add("test_file")
+	return "committed something!", &object.Signature{Name: "author", Email: "test@currencycloud.com"}, nil
+}
+
+func temporalDir() (path string, clean func()) {
+	fs := osfs.New(os.TempDir())
+	path, err := util.TempDir(fs, "", "")
+	if err != nil {
+		panic(err)
+	}
+
+	return fs.Join(fs.Root(), path), func() {
+		util.RemoveAll(fs, path)
+	}
+}
+
+func TestPushCommit(t *testing.T) {
+	// Given a cloned repository
+	repo, err := initGitRepo()
+	assert.Nil(t, err)
+
+	fs := memfs.New()
+	pr, err := makeGithubPR("shteou/go-ghpr", Credentials{}, &fs, new(mockGoGit))
+	assert.Nil(t, err)
+	pr.gitRepo = repo
+
+	// And a remote repository
+	// NOTE: The origin repository will be set when cloned. We're testing
+	// the push behaviour, so mock out a local remote
+	targetFs, clean := temporalDir()
+	defer clean()
+	originRepo, err := git.PlainInit(targetFs, true)
+	assert.Nil(t, err)
+	assert.NotNil(t, originRepo)
+
+	_, err = pr.gitRepo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{targetFs},
+	})
+	assert.Nil(t, err)
+
+	// When I make and push the commit
+	err = pr.PushCommit("my-branch", commitNothing)
+
+	// Then there are no errors
+	assert.Nil(t, err)
+
+	// And the commit has been pushed to the remote repository
+	commitIter, err := originRepo.CommitObjects()
+	assert.Nil(t, err)
+
+	count := 0
+	commitIter.ForEach(func(c *object.Commit) error {
+		count += 1
+		return nil
+	})
+
+	assert.Equal(t, 2, count, "The remote repository had the wrong number of commits")
 }

--- a/pkg/ghpr/ghpr_test.go
+++ b/pkg/ghpr/ghpr_test.go
@@ -175,11 +175,7 @@ func TestCloneFailure(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func commitNothing(w *git.Worktree) (string, *object.Signature, error) {
-	f, _ := w.Filesystem.Create("test_file")
-	_, _ = f.Write([]byte("My data"))
-	_ = f.Close()
-	w.Add("test_file")
+func commitSomething(w *git.Worktree) (string, *object.Signature, error) {
 	return "committed something!", &object.Signature{Name: "author", Email: "test@currencycloud.com"}, nil
 }
 
@@ -221,7 +217,7 @@ func TestPushCommit(t *testing.T) {
 	assert.Nil(t, err)
 
 	// When I make and push the commit
-	err = pr.PushCommit("my-branch", commitNothing)
+	err = pr.PushCommit("my-branch", commitSomething)
 
 	// Then there are no errors
 	assert.Nil(t, err)


### PR DESCRIPTION
Added a test for the happy path of the PushCommit method, by supplying
a mocked filesystem repository to push to. This saves mocking the
entire go-git Repository and Worktree types and aligns with how
they implement their own tests