### PR TITLE
feat: use timeout context for PR operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,23 @@ func PushDockerfileDeletionBranch(owner string, name string) error {
 		return err
 	}
 
-	pr := ghpr.NewPR(change, creds)
-	pr.Create("master", "chore: make change", "")
+	timeout, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*30))
+	defer cancel()
 
-	err = pr.WaitForPRStatus(strategy)
+	pr := ghpr.NewPR(timeout, change, creds)
+	pr.Create(timeout, "master", "chore: make change", "")
+
+	err = pr.WaitForPRStatus(timeout, strategy)
 	if err != nil {
 		return err
 	}
 
-	err = pr.Merge("merge")
+	err = pr.Merge(timeout, "merge")
 	if err != nil {
 		return err
 	}
 
-	return pr.WaitForMergeStatus(strategy)
+	return pr.WaitForMergeStatus(timeout, strategy)
 }
 
 func main() {

--- a/pkg/ghpr/ghpr.go
+++ b/pkg/ghpr/ghpr.go
@@ -32,8 +32,6 @@ type StatusWaitStrategy struct {
 	MaxPollTime time.Duration
 	// The poll time will be multiplied by this (up to max)
 	PollBackoffFactor float32
-	// The total timeout for the wait operation
-	Timeout time.Duration
 	// WaitStatusContext indicates the name of the status check to wait for
 	WaitStatusContext string
 }


### PR DESCRIPTION
Added a context parameter to all PR operations allowing the user
to specify their timeout as a standard context.WithTimeout, rather
than a parameter to the wait strategy.