### PR TITLE
docs: remove timeout parameter in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ func PushDockerfileDeletionBranch(owner string, name string) error {
 		MinPollTime:       time.Second * 20,
 		MaxPollTime:       time.Second * 60,
 		PollBackoffFactor: 1.05,
-		Timeout:           time.Minute * 10,
 		WaitStatusContext: "Semantic Pull Request",
 	}
 


### PR DESCRIPTION
The README provided an incorrect parameter to the StatusWaitStrategy
object. This no longer requires a Timeout value.