### PR TITLE
feat: support waiting for multple statuses

### DIFF
--- a/pkg/ghpr/examples_test.go
+++ b/pkg/ghpr/examples_test.go
@@ -68,22 +68,19 @@ func ExamplePR_WaitForPRStatus() {
 	pr, _ := basicPR()
 	_ = pr.Create(context.Background(), "main", "chore: remove obsolete files", "")
 
-	strategy := ghpr.StatusWaitStrategy{
+	strategy := ghpr.BackoffStrategy{
 		MinPollTime:       10 * time.Second,
 		MaxPollTime:       60 * time.Second,
 		PollBackoffFactor: 1.05,
-		WaitStatusContext: "Semantic Pull Request",
 	}
-	_ = pr.WaitForPRStatus(context.Background(), strategy)
+	statusChecks := []ghpr.Check{{Name: "Semantic Pull Request", CheckType: "status"}}
+
+	_ = pr.WaitForPRChecks(context.Background(), statusChecks, strategy)
 }
 
 func ExamplePR_Merge() {
 	pr, _ := basicPR()
 	_ = pr.Create(context.Background(), "main", "chore: remove obsolete files", "")
-
-	strategy := ghpr.StatusWaitStrategy{MinPollTime: 10 * time.Second, MaxPollTime: 60 * time.Second, PollBackoffFactor: 1.05, WaitStatusContext: "Semantic Pull Request"}
-	_ = pr.WaitForPRStatus(context.Background(), strategy)
-
 	_ = pr.Merge(context.Background(), "squash")
 }
 
@@ -91,9 +88,10 @@ func ExamplePR_WaitForMergeStatus() {
 	pr, _ := basicPR()
 	_ = pr.Create(context.Background(), "main", "chore: remove obsolete files", "")
 
-	strategy := ghpr.StatusWaitStrategy{MinPollTime: 10 * time.Second, MaxPollTime: 60 * time.Second, PollBackoffFactor: 1.05, WaitStatusContext: "Semantic Pull Request"}
-	_ = pr.WaitForPRStatus(context.Background(), strategy)
+	strategy := ghpr.BackoffStrategy{MinPollTime: 10 * time.Second, MaxPollTime: 60 * time.Second, PollBackoffFactor: 1.05}
+	statusChecks := []ghpr.Check{{Name: "Semantic Pull Request", CheckType: "status"}}
+	_ = pr.WaitForPRChecks(context.Background(), statusChecks, strategy)
 	_ = pr.Merge(context.Background(), "squash")
 
-	_ = pr.WaitForMergeStatus(context.Background(), strategy)
+	_ = pr.WaitForMergeChecks(context.Background(), statusChecks, strategy)
 }

--- a/pkg/ghpr/ghpr.go
+++ b/pkg/ghpr/ghpr.go
@@ -1,6 +1,7 @@
 package ghpr
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -11,6 +12,8 @@ import (
 // to the git WorkTree. These changes will be automatically committed on successful
 // return by the PushCommit function
 type UpdateFunc func(w *git.Worktree) (string, *object.Signature, error)
+
+type WaitFunc func(ctx context.Context, p PR) error
 
 // Credentials represents a GitHub username and PAT
 type Credentials struct {
@@ -24,14 +27,20 @@ type Author struct {
 	Email string
 }
 
-// StatusWaitStrategy describes how to wait for a GitHub status check
-type StatusWaitStrategy struct {
+// BackoffStrategy provides describes how to wait for a GitHub status check
+type BackoffStrategy struct {
 	// The initial wait time
 	MinPollTime time.Duration
 	// The max wait time when polling for a status
 	MaxPollTime time.Duration
 	// The poll time will be multiplied by this (up to max)
 	PollBackoffFactor float32
-	// WaitStatusContext indicates the name of the status check to wait for
-	WaitStatusContext string
+}
+
+// Check represents a GitHub action result or status
+type Check struct {
+	// Name of the check, e.g. "Semantic Pull Request"
+	Name string
+	// CheckType the type of check, either "action" or "status"
+	CheckType string
 }

--- a/pkg/ghpr/ghpr.go
+++ b/pkg/ghpr/ghpr.go
@@ -1,7 +1,6 @@
 package ghpr
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -12,8 +11,6 @@ import (
 // to the git WorkTree. These changes will be automatically committed on successful
 // return by the PushCommit function
 type UpdateFunc func(w *git.Worktree) (string, *object.Signature, error)
-
-type WaitFunc func(ctx context.Context, p PR) error
 
 // Credentials represents a GitHub username and PAT
 type Credentials struct {


### PR DESCRIPTION
Updated WaitFor(PR|Merge)Status to wait for multiple 'Checks'
and renamed accordingly. Checks may be statuses or actions, but
only the former is implemented